### PR TITLE
Update svn clone location

### DIFF
--- a/deploy-common.sh
+++ b/deploy-common.sh
@@ -4,8 +4,18 @@ CURRENTDIR=`pwd`
 # git config
 GITPATH="$CURRENTDIR/" # this file should be in the base of your git repository
 
+# create directory if custom path is provided for svn cloning.
+if [ ! -z "$SVNCLONEPATH" ]; then
+  mkdir -p "$SVNCLONEPATH"
+fi
+
 # svn config
-SVNPATH="/tmp/$PLUGINSLUG" # path to a temp SVN repo. No trailing slash required and don't add trunk.
+if [ -d "$SVNCLONEPATH" ]; then
+  SVNPATH=$SVNCLONEPATH/$PLUGINSLUG; # path to a custom temp SVN repo. No trailing slash required and don't add trunk.
+else
+  SVNPATH="/tmp/$PLUGINSLUG" # path to a temp SVN repo. No trailing slash required and don't add trunk.
+fi
+
 SVNURL="https://plugins.svn.wordpress.org/$PLUGINSLUG/" # Remote SVN repo on wordpress.org, with no trailing slash
 
 # Detect svn username based on url
@@ -93,7 +103,10 @@ svn copy trunk/ tags/$NEWVERSION1/
 cd $SVNPATH/tags/$NEWVERSION1
 svn commit --username=$SVNUSER -m "Tagging version $NEWVERSION1"
 
-echo "Removing temporary directory $SVNPATH"
-rm -fr $SVNPATH/
+# Remove tmp directory after commit.
+if [ -z "$SVNCLONEPATH" ]; then
+  echo "Removing temporary directory $SVNPATH"
+  rm -fr $SVNPATH/
+fi
 
 echo "*** FIN ***"


### PR DESCRIPTION
clone svn to a custom location if provided. Only delete `/tmp` directory. 

No change in existing behaviour. If a custom path is not provided.

This will be part of the plugin repo that wants a custom location.
```
export SVNCLONEPATH="$HOME/wp-svn"
export PLUGINSLUG="hello-dolly"
```

Script used for testing.
```
if [ ! -z "$SVNCLONEPATH" ]; then
  mkdir -p "$SVNCLONEPATH"
fi

# svn config
if [ -d "$SVNCLONEPATH" ]; then
  SVNPATH=$SVNCLONEPATH/$PLUGINSLUG;
else
  SVNPATH="/tmp/$PLUGINSLUG"
fi

SVNURL="https://plugins.svn.wordpress.org/$PLUGINSLUG/" # Remote SVN repo on wordpress.org, with no trailing slash

svn co $SVNURL $SVNPATH

if [ -z "$SVNCLONEPATH" ]; then
  echo "Removing temporary directory $SVNPATH"
  rm -fr $SVNPATH/
fi
```

We won't remove cloned files if a custom location is provided so it will help in reducing the time it takes to clone all tags.